### PR TITLE
Update registry.rs

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -158,7 +158,8 @@ impl RegistryManager {
         }
 
         let final_path = target_dir.join(filename);
-        tokio::fs::rename(&temp_path, &final_path).await?;
+        tokio::fs::copy(&temp_path, &final_path).await?;
+        tokio::fs::remove_file(&temp_path).await?;
 
         Ok(final_path)
     }


### PR DESCRIPTION
Fixes ``invalid cross device link`` error when on more advanced Unix fs structures